### PR TITLE
Api/covarage zone

### DIFF
--- a/metrics/app/enums.py
+++ b/metrics/app/enums.py
@@ -82,3 +82,8 @@ class ProvisionOptionEnum(Enum):  # todo int inheritance
 class ProvisionGetInfoObjectTypeEnum(str, AutoName):
     house = auto()
     service = auto()
+
+
+class CoverageZonesMethodEnum(str, AutoName):
+    radius = auto()
+    isochrone = auto()

--- a/metrics/app/routers.py
+++ b/metrics/app/routers.py
@@ -31,6 +31,7 @@ class Tags(str, enums.AutoName):
     collocation_matrix = auto()
     city_context = auto()
     master_plan = auto()
+    coverage_zone = auto()
 
 
 @router.get("/")
@@ -272,3 +273,16 @@ def master_plan_get_master_plan(
     master_plan_params = user_request.dict(exclude={"city"})
     master_plan = Masterplan(city_model)
     return master_plan.get_masterplan(**master_plan_params)["indicators"]
+
+
+@router.post(
+    "/coverage_zone/get_coverage_zone",
+    response_model=dict, tags=[Tags.coverage_zone],
+)
+def master_plan_get_master_plan(
+        user_request: schemas.CoverageZonesIn
+):
+    city_model = city_models[user_request.city]
+    coverage_zone = Coverage_Zones(city_model)
+    coverage_zone_params = user_request.dict(exclude={"city"})
+    return coverage_zone.get_coverage_zone(**coverage_zone_params)

--- a/metrics/app/schemas.py
+++ b/metrics/app/schemas.py
@@ -526,3 +526,24 @@ class MasterPlanOut(BaseModel):
     living_area_provision: float
     land_business_area: float
     building_height_mode: float
+
+
+class CoverageZonesIn(BaseModel):
+    city: enums.CitiesEnum
+    service_type: str
+    method: enums.CoverageZonesMethodEnum
+    radius: Optional[float] = None
+    travel_type: Optional[enums.MobilityAnalysisIsochronesTravelTypeEnum] = None
+    weight_value: Optional[conint(ge=1)] = None
+    routes: bool = False
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "city": "saint-petersburg",
+                "service_type": "schools",
+                "method": "radius",
+                "radius": 1000,
+                "routes": False
+            }
+        }

--- a/metrics/calculations/CityMetricsMethods.py
+++ b/metrics/calculations/CityMetricsMethods.py
@@ -2,6 +2,7 @@ import warnings
 warnings.filterwarnings('ignore')
 
 from typing import Any, Optional, Literal
+from traceback import print_exc
 import geopandas as gpd
 import shapely
 import pandas as pd
@@ -943,14 +944,13 @@ class Coverage_Zones(BaseMethod):
         self.services = self.city_model.Services.copy()
         self.walk_speed = 4 * 1000 / 60
 
-    def get_coverage_zone(self, service_type, method: Literal['radius', 'isochrone'], radius=None, travel_type = None, weight_value = None, _routes = False):
+    def get_coverage_zone(self, service_type, method: Literal['radius', 'isochrone'], radius=None, travel_type=None, weight_value=None, routes=False):
 
         services = self.services[self.services["service_code"] == service_type].reset_index(drop=True)
         service_types = self.service_types
 
         if method == 'radius':
-
-            if radius != None:
+            if radius is not None:
                 radius = radius
             else:
                 try:
@@ -960,6 +960,7 @@ class Coverage_Zones(BaseMethod):
                     elif service_types[service_types['code'] == service_type].iloc[0]['public_transport_time_normative'] != 0:
                         radius = service_types[service_types['code'] == service_type].iloc[0]['public_transport_time_normative'] * self.walk_speed
                 except:
+                    print_exc()
                     raise ValueError('radius')
 
             services['geometry'] = services.geometry.buffer(radius) 
@@ -971,7 +972,7 @@ class Coverage_Zones(BaseMethod):
             x_from = services['geometry'].x
             y_from = services['geometry'].y
             isochrone = AccessibilityIsochrones_v2(self.city_model).get_isochrone(
-                            travel_type, x_from, y_from, weight_value, weight_type = 'time_min', routes = _routes)
+                            travel_type, x_from, y_from, weight_value, weight_type='time_min', routes=routes)
             return isochrone
         
         return 


### PR DESCRIPTION
Добавлен API интерфейс для метрики CoverageZones. 

Для AccessibilityIsochrones_v2 интерфейс не писал. 

@pogoAnka [Здесь](7bb5c8fba59e0b3ec6ce52b74392a47413401f92) сделал небольшой рефакторинг
1. _router аргумент. У нижнего подчеркивания вначале переменной есть определенный дополнительный смысл. См. [PEP8](https://pythonworld.ru/osnovy/pep-8-rukovodstvo-po-napisaniyu-koda-na-python.html#section-17)
В данном контексте это не совсем уместно, не совсем понял зачем это, поэтому просто убрал
2. != None, так не сравнивается. Если хочется проверить, за какой-то переменной скрывается None или нет, то это is None. См. [PEP8](https://pythonworld.ru/osnovy/pep-8-rukovodstvo-po-napisaniyu-koda-na-python.html#section-31)
3. Очень нехорошая практика отлавливать общие ошибки( Потом концов не сыщешь, почему работает не так как надо.  
```python
try:
    ...
except:
    ...
```
Либо надо отлавливать конкретную ошибку которую действительно ожидается. Если не понятно, что за ошибка может быть есть в модуле `traceback` функция `print_exc()`, так хотя бы будет печататься исходная ошибка. `print_exc()` тоже не лучшее решение, но уже лучше чем ничего