### PR TITLE
Add cities caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,7 @@ dmypy.json
 .idea/
 env
 test.ipynb
+
+# other
+
+cities_cache/

--- a/metrics/app/core/config.py
+++ b/metrics/app/core/config.py
@@ -4,10 +4,23 @@ from pydantic import BaseSettings
 
 
 class Settings(BaseSettings):
+    """Application global config class, attributes can be modified via environment variables."""
+
     BASE_DIR: str = str(Path(__file__).resolve().parent.parent.parent)
-    DATA_DIR: str = str(Path(__file__).resolve().parent.parent.parent.parent)
+    """Metrics module base directory (CityGeoTools/metrics)."""
+
+    DATA_DIR: str = str(Path(__file__).resolve().parent.parent.parent.parent) # seems to be unused
+    """Whole project base directory."""
+
+    CITIES_CACHE_DIR = str(Path(__file__).resolve().parent.parent.parent.parent / "cities_cache")
+    """Directory with pickle files of cities data to fasten metrics startup process."""
+
+    UPDATE_CITIES_CACHE: bool = False
+    """Indicates whether cached cities need to be re-downloaded on startup."""
 
     FASTAPI_DEBUG: bool = True
+    """FastAPI debug flag."""
 
 
 settings = Settings()
+"""Settings singleton to use across application."""


### PR DESCRIPTION
Repeat of https://github.com/iduprojects/CityGeoTools/pull/74

Changes:
- environment variables CITIES_CACHE_DIR and UPDATE_CITIES_CACHE are used in metrics/app/core/config to manipulate cities caches
- after cities data is collected from database and graphs are built, they are stored in cities_cache directory if it is available
- if cities data is fully found in cache, nothing is downloaded from RPYC unless UPDATE_CITIES_CACHE is set to true